### PR TITLE
Ensure single H1 per page

### DIFF
--- a/app.html
+++ b/app.html
@@ -217,7 +217,7 @@
                         <div class="orbit-ring"></div>
                         <div class="orbit-ring orbit-ring-2"></div>
                     </div>
-                    <h1>Nova — Your smart community manager and your personal assistant on Telegram</h1>
+                    <h2>Nova — Your smart community manager and your personal assistant on Telegram</h2>
                     <p>Transparent platform with pay‑per‑use pricing and reliable service.</p>
                     <a href="https://t.me/NovaInferencoBot" class="cta-button" aria-label="Start with Nova Bot">Start with Nova Bot</a>
                 </div>


### PR DESCRIPTION
## Summary
- Downgraded Nova hero heading in `app.html` to `<h2>` so the page keeps a single `<h1>`.
- Verified that `app.html`, `nova.html`, and `index.html` each contain exactly one top-level `<h1>`.

## Testing
- `npx --yes htmlhint app.html index.html nova.html`


------
https://chatgpt.com/codex/tasks/task_e_68bb0cdd0dc88321a739c394247fd12d