### PR TITLE
feat: highlight on-chain AI in pages

### DIFF
--- a/app.html
+++ b/app.html
@@ -7,14 +7,14 @@
     <!-- Primary Meta Tags -->
     <title>Inferenco – Transparent Blockchain & AI Applications Platform</title>
     <meta name="title" content="Inferenco – Transparent Blockchain & AI Applications Platform">
-    <meta name="description" content="Inferenco develops transparent blockchain and AI applications with pay‑per‑use pricing. Build on existing blockchains, enjoy complete cost transparency and seamless Web3 integrations.">
-    <meta name="keywords" content="blockchain AI, AI applications, transparent AI, pay per use AI, enterprise AI, Web3 tools, crypto communities, decentralised AI, Nova AI, Telegram AI bot">
+    <meta name="description" content="Inferenco develops transparent on-chain AI and blockchain applications with pay‑per‑use pricing. Build on existing blockchains, enjoy complete cost transparency and seamless Web3 integrations.">
+    <meta name="keywords" content="on-chain AI, blockchain AI, AI applications, transparent AI, pay per use AI, enterprise AI, Web3 tools, crypto communities, decentralised AI, Nova AI, Telegram AI bot">
 
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://inferenco.com/">
     <meta property="og:title" content="Inferenco – Transparent Blockchain & AI Applications Platform">
-    <meta property="og:description" content="Developing blockchain‑powered AI applications with complete cost transparency and pay‑per‑use pricing for enterprise and Web3 communities.">
+    <meta property="og:description" content="Developing on-chain AI and blockchain-powered applications with complete cost transparency and pay‑per‑use pricing for enterprise and Web3 communities.">
     <meta property="og:image" content="https://inferenco.com/assets/logos/horizontal-logo.png">
     <meta property="og:site_name" content="Inferenco">
     <meta property="og:image:alt" content="Inferenco horizontal logo">
@@ -24,7 +24,7 @@
     <meta property="twitter:card" content="summary_large_image">
     <meta property="twitter:url" content="https://inferenco.com/">
     <meta property="twitter:title" content="Inferenco – Transparent Blockchain & AI Applications Platform">
-    <meta property="twitter:description" content="Developing blockchain‑powered AI applications with complete cost transparency and pay‑per‑use pricing for enterprise and Web3 communities.">
+    <meta property="twitter:description" content="Developing on-chain AI and blockchain-powered applications with complete cost transparency and pay‑per‑use pricing for enterprise and Web3 communities.">
     <meta property="twitter:image" content="https://inferenco.com/assets/logos/horizontal-logo.png">
     <meta name="twitter:image:alt" content="Inferenco horizontal logo">
 
@@ -63,7 +63,7 @@
         "alternateName": "Inferenco AI",
         "url": "https://inferenco.com",
         "logo": "https://inferenco.com/assets/logos/flame.png",
-        "description": "Inferenco builds transparent blockchain and AI applications with pay‑per‑use pricing.",
+        "description": "Inferenco builds transparent on-chain AI applications with pay‑per‑use pricing.",
         "foundingDate": "2025",
         "founders": [
             {
@@ -86,7 +86,7 @@
                     "itemOffered": {
                         "@type": "Service",
                         "name": "Nova - AI & Blockchain Tools",
-                        "description": "Telegram-based AI and blockchain tools with transparent pay‑per‑use billing"
+                        "description": "Telegram-based on-chain AI and blockchain tools with transparent pay‑per‑use billing"
                     }
                 }
             ]
@@ -142,8 +142,8 @@
                     <div class="hero-logo">
                         <img src="assets/logos/flame.png" alt="Inferenco platform logo" class="main-logo-animated">
                     </div>
-                    <h1>Developing blockchain&nbsp;& AI applications for Web3 leaders & Crypto Communities.</h1>
-                    <p>Transparent, pay‑per‑use AI tools built on existing blockchains with seamless Web3 integrations.</p>
+                    <h1>Developing blockchain&nbsp;& on-chain AI applications for Web3 leaders & Crypto Communities.</h1>
+                    <p>Transparent, pay‑per‑use on-chain AI tools built on existing blockchains with seamless Web3 integrations.</p>
                     <a href="#nova" class="cta-button nav-link" data-page="nova" aria-label="Discover Nova">Discover Nova</a>
                 </div>
             </section>

--- a/nova.html
+++ b/nova.html
@@ -15,14 +15,14 @@
     <title>Nova - Your smart community manager and your personal assistant on Telegram</title>
     <!-- Updated: 2025-01-02 -->
     <meta name="title" content="Nova - Your smart community manager and your personal assistant on Telegram">
-    <meta name="description" content="Nova by Inferenco: Transparent AI and blockchain tools in Telegram with pay‑per‑use billing. Includes GPT‑5, image generation, payments, Sentinel protection, DAO voting and more.">
-    <meta name="keywords" content="Nova AI, Telegram AI bot, blockchain tools, pay per use AI, GPT‑5 Telegram, transparent billing, community management, DAO voting, Sentinel protection">
+    <meta name="description" content="Nova by Inferenco: Transparent on-chain AI and blockchain tools in Telegram with pay‑per‑use billing. Includes GPT‑5, image generation, payments, Sentinel protection, DAO voting and more.">
+    <meta name="keywords" content="on-chain AI, Nova AI, Telegram AI bot, blockchain tools, pay per use AI, GPT‑5 Telegram, transparent billing, community management, DAO voting, Sentinel protection">
 
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="product">
     <meta property="og:url" content="https://inferenco.com/nova">
     <meta property="og:title" content="Nova - Your smart community manager and your personal assistant on Telegram">
-    <meta property="og:description" content="Transparent AI and blockchain tools in Telegram with pay‑per‑use billing. Includes GPT‑5, image generation, payments, Sentinel protection, DAO voting and more.">
+    <meta property="og:description" content="Transparent on-chain AI and blockchain tools in Telegram with pay‑per‑use billing. Includes GPT‑5, image generation, payments, Sentinel protection, DAO voting and more.">
     <meta property="og:image" content="https://inferenco.com/assets/logos/nova.png">
     <meta property="og:site_name" content="Inferenco">
     <meta property="og:image:alt" content="Nova circular logo">
@@ -32,7 +32,7 @@
     <meta property="twitter:card" content="summary_large_image">
     <meta property="twitter:url" content="https://inferenco.com/nova">
     <meta property="twitter:title" content="Nova - Your smart community manager and your personal assistant on Telegram">
-    <meta property="twitter:description" content="Transparent AI and blockchain tools in Telegram with pay‑per‑use billing. Includes GPT‑5, image generation, payments, Sentinel protection, DAO voting and more.">
+    <meta property="twitter:description" content="Transparent on-chain AI and blockchain tools in Telegram with pay‑per‑use billing. Includes GPT‑5, image generation, payments, Sentinel protection, DAO voting and more.">
     <meta property="twitter:image" content="https://inferenco.com/assets/logos/nova.png">
     <meta name="twitter:image:alt" content="Nova circular logo">
 
@@ -68,7 +68,7 @@
         "@type": "SoftwareApplication",
         "name": "Nova",
         "alternateName": "Nova AI Bot",
-        "description": "AI and blockchain tools integrated with Telegram, offering transparent billing and pay‑per‑use services including GPT‑5, image generation, payments, DAO voting and group protection.",
+        "description": "On-chain AI and blockchain tools integrated with Telegram, offering transparent billing and pay‑per‑use services including GPT‑5, image generation, payments, DAO voting and group protection.",
         "url": "https://inferenco.com/nova",
         "applicationCategory": "BusinessApplication",
         "operatingSystem": "Web-based, Telegram",
@@ -190,8 +190,8 @@
                     We removed the word “Revolutionary” and the implication that
                     we operate our own chain.
                 -->
-                <h1>Nova — Your smart community manager and your personal assistant on Telegram</h1>
-                <p>Transparent platform with pay‑per‑use pricing and reliable service.</p>
+                <h1>Nova — Your smart community manager and on-chain AI personal assistant on Telegram</h1>
+                <p>Transparent on-chain AI platform with pay‑per‑use pricing and reliable service.</p>
                 <a href="https://t.me/NovaInferencoBot" class="cta-button" aria-label="Start with Nova Bot">Start with Nova Bot</a>
             </div>
         </section>


### PR DESCRIPTION
## Summary
- feature app and Nova pages now emphasize on-chain AI in headings and copy
- update meta descriptions and keywords to mention on-chain AI

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb0cd721f48321b29ca50b75a15165