### PR TITLE
Fix/download aarch64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 dist
 .DS_Store
+screenshots

--- a/src/pages/NovaDesk.tsx
+++ b/src/pages/NovaDesk.tsx
@@ -34,12 +34,17 @@ const getDownloadUrl = (os: OS): string => {
 
 export default function NovaDesk() {
   const detectedOS = detectOS();
-  const downloadUrl = getDownloadUrl(detectedOS);
   const isUnknownOS = detectedOS === "unknown";
   const isMacOS = detectedOS === "mac";
   const showAllButtons = isUnknownOS || isMacOS;
   
-  const shouldShow = (os: OS): boolean => detectedOS === os || showAllButtons;
+  // On Linux, always show both x64 and ARM64 buttons since we can't reliably
+  // detect architecture from browser (Raspberry Pi OS reports x86_64 in userAgent
+  // even when running on ARM64 hardware)
+  const shouldShow = (os: OS): boolean => {
+    if (detectedOS === "linux" && (os === "linux" || os === "linux-arm64")) return true;
+    return detectedOS === os || showAllButtons;
+  };
 
   return (
     <div id="nova-desk-page" className="page-section">
@@ -65,7 +70,7 @@ export default function NovaDesk() {
           <div className="download-buttons">
             {shouldShow("windows") && (
               <a
-                href={downloadUrl}
+                href={getDownloadUrl("windows")}
                 className="cta-button"
                 aria-label="Download for Windows"
                 target="_blank"
@@ -85,7 +90,7 @@ export default function NovaDesk() {
             )}
             {shouldShow("linux") && (
               <a
-                href={downloadUrl}
+                href={getDownloadUrl("linux")}
                 className="cta-button"
                 aria-label="Download for Linux x64"
                 target="_blank"
@@ -96,7 +101,7 @@ export default function NovaDesk() {
             )}
             {shouldShow("linux-arm64") && (
               <a
-                href={downloadUrl}
+                href={getDownloadUrl("linux-arm64")}
                 className="cta-button"
                 aria-label="Download for Linux ARM64"
                 target="_blank"


### PR DESCRIPTION
# PR: Fix Linux ARM64 Detection Issue

## Summary
Fixes issue where Raspberry Pi OS (ARM64) incorrectly showed only the Linux x64 download button instead of both x64 and ARM64 options.

## Problem
Browser's `navigator.userAgent` on Raspberry Pi OS reports `Linux x86_64` even when running on ARM64 hardware. This makes it impossible to reliably detect the actual kernel architecture from client-side JavaScript alone.

## Solution
Modified the download button logic in `src/pages/NovaDesk.tsx` to always show both Linux buttons when Linux is detected, allowing users to manually select their architecture.

## Changes
- Updated `shouldShow()` function to show both Linux x64 and Linux ARM64 buttons when Linux is detected
- Fixed button URLs to use architecture-specific download URLs
- Removed unused `downloadUrl` variable

## Testing
- ✅ Build passes successfully
- ✅ TypeScript compilation succeeds
- ✅ Both Linux buttons appear when Linux is detected
- ✅ Each button links to the correct architecture-specific URL

## Files Modified
- `src/pages/NovaDesk.tsx` (10 insertions, 5 deletions)

## Impact
- Linux users can now manually select the correct architecture
- Raspberry Pi users can download the ARM64 version
- No breaking changes to existing functionality
