### PR TITLE
fix: update Nova Desk fallback version from v0.1.1 to v0.2.0

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,223 +1,38 @@
-# Pull Request: Update Nova Desk Page with Dynamic Version and Enhanced Features
+# Pull Request: Update Nova Desk Fallback Version to v0.2.0
 
 ## Overview
 
-This PR updates the Nova Desk landing page to:
-1. **Fetch latest release version dynamically** from GitHub API
-2. **Update feature descriptions** to accurately reflect Nova Desk capabilities
-3. **Add missing features** that were implemented in the desktop application
-4. **Improve button hover consistency** across the site
-5. **Add developer documentation** section for Nova Connect integration
+This PR updates the fallback version for Nova Desk downloads from `v0.1.1` to `v0.2.0` to address a critical issue where version 0.1.1 creates accounts with seed words that don't match the account.
 
 ## Changes Made
 
-### 1. Dynamic Version Detection (`src/services/github.ts` - NEW)
+### 1. Updated Fallback Version in GitHub Service (`src/services/github.ts`)
 
-**Created new GitHub API service** to fetch latest release version:
+Changed the fallback version in `getLatestReleaseVersion()` from `v0.1.1` to `v0.2.0`:
 
 ```typescript
-export const getLatestReleaseVersion = async (): Promise<string> => {
-  try {
-    const response = await fetch(
-      `https://api.github.com/repos/Inferenco/nova-desk-releases/releases/latest`
-    );
-    const data = await response.json();
-    return data.tag_name as string;
-  } catch (error) {
-    console.error("Failed to fetch latest version:", error);
-    return "v0.1.1"; // Fallback
-  }
-};
-
-export const getDownloadUrl = (os: OS, version: string): string => {
-  const base = `https://github.com/Inferenco/nova-desk-releases/releases/download/${version}`;
-  switch (os) {
-    case "windows": return `${base}/NovaDesk-Windows-x64.exe`;
-    case "linux": return `${base}/NovaDesk-x86_64.AppImage`;
-    case "linux-arm64": return `${base}/NovaDesk-aarch64.AppImage`;
-    default: return `https://github.com/Inferenco/nova-desk-releases/releases/latest`;
-  }
-};
+return "v0.2.0"; // Fallback
 ```
 
-**Impact**: Downloads now always point to the latest version automatically, eliminating manual version updates.
+### 2. Updated Initial State in NovaDesk Component (`src/pages/NovaDesk.tsx`)
 
-### 2. Updated NovaDesk Component (`src/pages/NovaDesk.tsx`)
+Changed the initial version state from `v0.1.1` to `v0.2.0`:
 
-**Added dynamic version fetching**:
-- Import GitHub service
-- Add `useEffect` to fetch latest version on component mount
-- Store version in state with fallback to "v0.1.1"
-- Update all download button URLs to use dynamic version
-
-**Updated dApp Browser description**:
-- **Before**: "Built-in DApp browser with WalletConnect support. Connect to the decentralized web directly from the desktop app."
-- **After**: "Use your favorite browser or the internal browser with Nova Connect. Seamlessly connect external browsers to Nova Desk for dApp access."
-
-**Added 4 new feature cards**:
-1. **Nova Connect Integration** (🔗): Connect external browsers to Nova Desk
-2. **External Device Storage** (💾): Store keys on external devices without hardware wallets
-3. **Dark & Light Themes** (🎨): Choose between themes for comfortable usage
-4. **System Tray Integration** (📤): Quick access from system tray
-
-**Added Developer section**:
-- Links to `/docs#nova-connect-introduction` for Nova Connect documentation
-- "View Documentation" button for easy access
-- Targeted at developers who want to integrate Nova Desk with their dApps
-
-### 3. Enhanced Button Hover Styles (`src/index.css`)
-
-**Updated `.cta-button:hover`**:
-```css
-.cta-button:hover {
-    background-color: var(--accent);  /* Cyan (#00e6ff) */
-    border-color: var(--accent);
-    color: #fff;                      /* White text */
-    transform: translateY(-2px);
-    box-shadow: 0 0 25px rgba(0, 230, 255, 0.6);
-}
+```typescript
+const [version, setVersion] = useState<string>("v0.2.0");
 ```
 
-**Updated `.cta-button.secondary:hover`**:
-```css
-.cta-button.secondary:hover {
-    background-color: var(--accent);
-    border-color: var(--accent);
-    color: #fff;
-}
-```
+## Impact
 
-**Impact**: All buttons now have consistent hover behavior - cyan background with white text.
-
-### 4. Fixed Developer Section Layout
-
-**Added proper z-index and padding**:
-```css
-.developer-content {
-    text-align: center;
-    max-width: 800px;
-    margin: 0 auto;
-    padding: 4rem 0;
-    position: relative;
-    z-index: 1;
-}
-```
-
-**Impact**: Prevents navigation bar from overlapping developer section text.
-
-### 5. Updated Link Styling
-
-**Removed underline from developer links**:
-```css
-.developer-content a {
-    color: var(--primary);
-    font-weight: 600;
-}
-```
-
-**Impact**: Links now match button text style instead of having underlines.
-
-## Final Feature Grid (10 cards total)
-
-### Existing Features (kept):
-1. ✅ Security First - AES-GCM encryption, Argon2 key derivation, brute-force protection
-2. ✅ Asset Management - Send/receive assets, manage CEDRA coins and tokens
-3. ✅ Auto Updates - Automatic update checks from GitHub releases
-4. ✅ Gaming & NFTs - View digital collectibles, Cedra-based games
-5. ✅ Audit Logging - Comprehensive security logging for all operations
-
-### Updated Features:
-6. ✅ dApp Browser - Updated description to mention Nova Connect
-
-### New Features Added:
-7. 🔗 Nova Connect Integration - Connect external browsers to Nova Desk
-8. 💾 External Device Storage - Store keys on external devices
-9. 🎨 Dark & Light Themes - Choose between themes
-10. 📤 System Tray Integration - Quick access from system tray
-
-### New Section:
-- **For Developers** - Nova Connect documentation and integration guide
-
-## Technical Details
-
-### Platform Support
-- ✅ Windows (x64)
-- ✅ Linux (x64, ARM64)
-- ✅ macOS (Coming Soon)
-
-### Version Detection
-- Uses GitHub Releases API: `https://api.github.com/repos/Inferenco/nova-desk-releases/releases/latest`
-- Falls back to "v0.1.1" if API fails
-- Updates automatically on component mount
-
-### OS Detection
-- Detects Windows, macOS, Linux
-- Shows both x64 and ARM64 buttons on Linux (can't reliably detect architecture from browser)
-- Graceful fallback for unknown OS
+- Downloads will now fall back to version 0.2.0 instead of 0.1.1 when GitHub API is unavailable
+- Resolves the issue with mismatched seed words and accounts in version 0.1.1
+- Ensures users get a stable, working version even if the latest version cannot be fetched
 
 ## Files Modified
 
 | File | Changes |
 |------|---------|
-| `src/services/github.ts` | ✨ NEW - GitHub API service (46 lines) |
-| `src/pages/NovaDesk.tsx` | 📝 Updated - Dynamic version + new features (59 lines changed) |
-| `src/index.css` | 🎨 Updated - Button hover + developer section styles (37 lines added) |
+| `src/services/github.ts` | Updated fallback version to v0.2.0 |
+| `src/pages/NovaDesk.tsx` | Updated initial state version to v0.2.0 |
 
-**Total**: 3 files changed, 142 insertions(+), 30 deletions(-)
-
-## Testing
-
-### Build Verification
-```bash
-pnpm build
-# ✓ built in 201ms
-```
-
-### TypeScript Compilation
-```bash
-pnpm tsc --noEmit
-# ✓ No errors
-```
-
-### Manual Testing
-- ✅ Version detection works (shows latest release)
-- ✅ Download buttons link to correct URLs
-- ✅ All feature cards visible
-- ✅ Developer section accessible
-- ✅ Button hover effects consistent
-- ✅ No text overlap issues
-
-## Screenshots
-
-Before | After
--------|-------
-![Before - Static version](screenshots/before.png) | ![After - Dynamic version](screenshots/after.png)
-
-## Migration Notes
-
-### For Users
-- No action required
-- Downloads automatically point to latest version
-- New features available immediately
-
-### For Developers
-- New GitHub service available at `src/services/github.ts`
-- Can be reused for other version detection needs
-- Follows existing TypeScript patterns
-
-## Related Issues
-
-- Resolves: Outdated feature descriptions
-- Resolves: Manual version updates required
-- Resolves: Missing Nova Connect documentation
-- Resolves: Inconsistent button hover styles
-
-## Conclusion
-
-This PR brings the Nova Desk landing page up-to-date with the actual desktop application features and provides a better user experience with:
-- Always-up-to-date download links
-- Accurate feature descriptions
-- Developer documentation access
-- Consistent visual design
-
-The implementation is production-ready with proper error handling and fallback mechanisms.
+**Total**: 2 files changed, 2 lines modified

--- a/src/pages/NovaDesk.tsx
+++ b/src/pages/NovaDesk.tsx
@@ -18,7 +18,7 @@ const detectOS = (): OS => {
 };
 
 export default function NovaDesk() {
-  const [version, setVersion] = useState<string>("v0.1.1");
+  const [version, setVersion] = useState<string>("v0.2.0");
   const detectedOS = detectOS();
   const isUnknownOS = detectedOS === "unknown";
   const isMacOS = detectedOS === "mac";

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -12,7 +12,7 @@ export const getLatestReleaseVersion = async (): Promise<string> => {
     return data.tag_name as string;
   } catch (error) {
     console.error("Failed to fetch latest version:", error);
-    return "v0.1.1"; // Fallback
+    return "v0.2.0"; // Fallback
   }
 };
 


### PR DESCRIPTION
# Pull Request: Update Nova Desk Fallback Version to v0.2.0

## Overview

This PR updates the fallback version for Nova Desk downloads from `v0.1.1` to `v0.2.0` to address a critical issue where version 0.1.1 creates accounts with seed words that don't match the account.

## Changes Made

### 1. Updated Fallback Version in GitHub Service (`src/services/github.ts`)

Changed the fallback version in `getLatestReleaseVersion()` from `v0.1.1` to `v0.2.0`:

```typescript
return "v0.2.0"; // Fallback
```

### 2. Updated Initial State in NovaDesk Component (`src/pages/NovaDesk.tsx`)

Changed the initial version state from `v0.1.1` to `v0.2.0`:

```typescript
const [version, setVersion] = useState<string>("v0.2.0");
```

## Impact

- Downloads will now fall back to version 0.2.0 instead of 0.1.1 when GitHub API is unavailable
- Resolves the issue with mismatched seed words and accounts in version 0.1.1
- Ensures users get a stable, working version even if the latest version cannot be fetched

## Files Modified

| File | Changes |
|------|---------|
| `src/services/github.ts` | Updated fallback version to v0.2.0 |
| `src/pages/NovaDesk.tsx` | Updated initial state version to v0.2.0 |

**Total**: 2 files changed, 2 lines modified
