### PR TITLE
feat: add FreeBSD download support for Nova Desk

### DIFF
--- a/src/pages/NovaDesk.tsx
+++ b/src/pages/NovaDesk.tsx
@@ -8,6 +8,7 @@ const detectOS = (): OS => {
 
   if (ua.includes("win") || platform.includes("win")) return "windows";
   if (ua.includes("mac") || platform.includes("mac")) return "mac";
+  if (ua.includes("freebsd") || platform.includes("freebsd")) return "freebsd";
   if (ua.includes("linux")) {
     if (ua.includes("arm64") || ua.includes("aarch64") || platform.includes("arm64")) {
       return "linux-arm64";
@@ -33,6 +34,7 @@ export default function NovaDesk() {
   // even when running on ARM64 hardware)
   const shouldShow = (os: OS): boolean => {
     if (detectedOS === "linux" && (os === "linux" || os === "linux-arm64")) return true;
+    if (detectedOS === "freebsd" && os === "freebsd") return true;
     return detectedOS === os || showAllButtons;
   };
 
@@ -98,6 +100,17 @@ export default function NovaDesk() {
                 rel="noopener noreferrer"
               >
                 <i className="fab fa-linux"></i> Linux ARM64
+              </a>
+            )}
+            {shouldShow("freebsd") && (
+              <a
+                href={getDownloadUrl("freebsd", version)}
+                className="cta-button"
+                aria-label="Download for FreeBSD"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <i className="fab fa-freebsd"></i> FreeBSD
               </a>
             )}
           </div>

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -1,4 +1,4 @@
-export type OS = "windows" | "mac" | "linux" | "linux-arm64" | "unknown";
+export type OS = "windows" | "mac" | "linux" | "linux-arm64" | "freebsd" | "unknown";
 
 const REPO_OWNER = "Inferenco";
 const REPO_NAME = "nova-desk-releases";
@@ -25,6 +25,8 @@ export const getDownloadUrl = (os: OS, version: string): string => {
       return `${base}/NovaDesk-x86_64.AppImage`;
     case "linux-arm64":
       return `${base}/NovaDesk-aarch64.AppImage`;
+    case "freebsd":
+      return `${base}/NovaDesk-FreeBSD-x86_64`;
     case "mac":
     case "unknown":
     default:


### PR DESCRIPTION
## PR: feat: add FreeBSD download support for Nova Desk

### Description
Add FreeBSD OS detection and download link support for Nova Desk downloads.

### Changes
- **`src/services/github.ts`:**
  - Added `"freebsd"` to the `OS` type union
  - Added `case "freebsd"` in `getDownloadUrl()` returning `NovaDesk-FreeBSD-x86_64`

- **`src/pages/NovaDesk.tsx`:**
  - Updated `detectOS()` to detect FreeBSD via `navigator.userAgent` and `navigator.platform`
  - Updated `shouldShow()` logic to display FreeBSD button for FreeBSD users
  - Added FreeBSD download button with Font Awesome icon

### Download URL
FreeBSD users will now get:
```
https://github.com/Inferenco/nova-desk-releases/releases/download/[version]/NovaDesk-FreeBSD-x86_64
```

### Testing
- ✅ Build passes (`pnpm run build`)
- ✅ TypeScript compiles without errors
- ✅ Existing OS detection (Windows, Linux, macOS) unaffected

### Related
Closes freebsd-download support requirement for Nova Desk package distribution.