### PR TITLE
feat: add testing script and update download URL logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build && cp dist/index.html dist/404.html",
+    "test": "node --test tests/*.test.mjs",
     "lint": "eslint .",
     "preview": "vite preview",
     "predeploy": "pnpm run build",

--- a/src/pages/NovaDesk.tsx
+++ b/src/pages/NovaDesk.tsx
@@ -1,5 +1,4 @@
-import { useEffect, useState } from "react";
-import { getDownloadUrl, getLatestReleaseVersion, type OS } from "../services/github";
+import { getDownloadUrl, type OS } from "../services/github";
 import LightboxGallery from "../components/LightboxGallery";
 
 const deskImages = [
@@ -20,7 +19,8 @@ const detectOS = (): OS => {
   const platform = navigator.platform.toLowerCase();
   
   // Check if we can access navigator.oscpu for more precise detection (Firefox)
-  const oscpu = (navigator as any).oscpu?.toLowerCase() || "";
+  const oscpu =
+    (navigator as Navigator & { oscpu?: string }).oscpu?.toLowerCase() || "";
 
   if (ua.includes("win") || platform.includes("win")) return "windows";
   if (ua.includes("freebsd") || platform.includes("freebsd")) return "freebsd";
@@ -44,15 +44,10 @@ const detectOS = (): OS => {
 };
 
 export default function NovaDesk() {
-  const [version, setVersion] = useState<string>("v0.2.0");
   const detectedOS = detectOS();
   const isUnknownOS = detectedOS === "unknown";
   const isMacOS = detectedOS === "mac" || detectedOS === "mac-intel" || detectedOS === "mac-arm64";
   const showAllButtons = isUnknownOS || isMacOS;
-
-  useEffect(() => {
-    getLatestReleaseVersion().then(setVersion);
-  }, []);
 
   // On Linux, always show both x64 and ARM64 buttons since we can't reliably
   // detect architecture from browser (Raspberry Pi OS reports x86_64 in userAgent
@@ -100,7 +95,7 @@ export default function NovaDesk() {
           <div className="download-buttons">
             {shouldShow("windows") && (
               <a
-                href={getDownloadUrl("windows", version)}
+                href={getDownloadUrl("windows")}
                 className="cta-button"
                 aria-label="Download for Windows"
                 target="_blank"
@@ -111,7 +106,7 @@ export default function NovaDesk() {
             )}
             {shouldShow("mac-intel") && (
               <a
-                href={getDownloadUrl("mac-intel", version)}
+                href={getDownloadUrl("mac-intel")}
                 className="cta-button"
                 aria-label="Download for macOS Intel"
                 target="_blank"
@@ -122,7 +117,7 @@ export default function NovaDesk() {
             )}
             {shouldShow("mac-arm64") && (
               <a
-                href={getDownloadUrl("mac-arm64", version)}
+                href={getDownloadUrl("mac-arm64")}
                 className="cta-button"
                 aria-label="Download for macOS Apple Silicon"
                 target="_blank"
@@ -133,7 +128,7 @@ export default function NovaDesk() {
             )}
             {shouldShow("linux") && (
               <a
-                href={getDownloadUrl("linux", version)}
+                href={getDownloadUrl("linux")}
                 className="cta-button"
                 aria-label="Download for Linux x64"
                 target="_blank"
@@ -144,7 +139,7 @@ export default function NovaDesk() {
             )}
             {shouldShow("linux-arm64") && (
               <a
-                href={getDownloadUrl("linux-arm64", version)}
+                href={getDownloadUrl("linux-arm64")}
                 className="cta-button"
                 aria-label="Download for Linux ARM64"
                 target="_blank"
@@ -155,7 +150,7 @@ export default function NovaDesk() {
             )}
             {shouldShow("freebsd") && (
               <a
-                href={getDownloadUrl("freebsd", version)}
+                href={getDownloadUrl("freebsd")}
                 className="cta-button"
                 aria-label="Download for FreeBSD"
                 target="_blank"

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -16,16 +16,16 @@ export const getLatestReleaseVersion = async (): Promise<string> => {
   }
 };
 
-export const getDownloadUrl = (os: OS, version: string): string => {
-  const base = `https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/download/${version}`;
+export const getDownloadUrl = (os: OS): string => {
+  const base = `https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/latest/download`;
   switch (os) {
     case "windows":
       return `${base}/NovaDesk-Windows-x64.exe`;
     case "mac":
     case "mac-intel":
-      return `${base}/NovaDesk-macOS-x86_64.dmg`;
+      return `${base}/NovaDesk-macOS-x86_64.zip`;
     case "mac-arm64":
-      return `${base}/NovaDesk-macOS-aarch64.dmg`;
+      return `${base}/NovaDesk-macOS-aarch64.zip`;
     case "linux":
       return `${base}/NovaDesk-x86_64.AppImage`;
     case "linux-arm64":

--- a/tests/download-urls.test.mjs
+++ b/tests/download-urls.test.mjs
@@ -1,0 +1,17 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const githubService = readFileSync(resolve(root, "src/services/github.ts"), "utf8");
+
+describe("Nova Desk download URLs", () => {
+  test("macOS downloads match the published zip release assets", () => {
+    assert.match(githubService, /releases\/latest\/download/);
+    assert.match(githubService, /NovaDesk-macOS-x86_64\.zip/);
+    assert.match(githubService, /NovaDesk-macOS-aarch64\.zip/);
+    assert.doesNotMatch(githubService, /NovaDesk-macOS-[^"`']+\.dmg/);
+  });
+});


### PR DESCRIPTION
- Add a new test script to package.json for running tests.
- Refactor getDownloadUrl function to remove version parameter and use the latest release for downloads.
- Update NovaDesk component to reflect changes in download URL logic, removing version dependency from download links.
- Clean up unused state and effects in NovaDesk component for improved performance.