### PR TITLE
feat: add Nova Ecosystem to Products and Portfolio

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,16 +1,17 @@
 import { useState, useEffect } from "react";
 import { Link, useLocation, Outlet } from "react-router-dom";
-import type { PageType } from "../types";
+import type { PageType, ProductDropdownItem } from "../types";
 
 const navLinks: { label: string; path: string; page: PageType }[] = [
   { label: "Home", path: "/", page: "home" },
   { label: "Docs", path: "/docs", page: "docs" },
 ];
 
-const productsDropdown = [
+const productsDropdown: ProductDropdownItem[] = [
   { label: "Nova Bot", path: "/nova", page: "nova" },
   { label: "Nova Wallet", path: "/nova-wallet", page: "nova-wallet" },
   { label: "Nova Desk", path: "/nova-desk", page: "nova-desk" },
+  { label: "Nova Ecosystem", path: "https://app.inferenco.com", external: true },
 ];
 
 const socialLinks = [
@@ -89,17 +90,33 @@ export default function Layout() {
           {productsDropdownOpen && (
             <div className="mobile-dropdown-content" id="mobile-products-dropdown">
               {productsDropdown.map((product) => (
-                <Link
-                  key={product.path}
-                  to={product.path}
-                  className={`nav-link ${isActive(product.path) ? "active" : ""}`}
-                  onClick={() => {
-                    setMobileMenuOpen(false);
-                    setProductsDropdownOpen(false);
-                  }}
-                >
-                  {product.label}
-                </Link>
+                product.external ? (
+                  <a
+                    key={product.path}
+                    href={product.path}
+                    className="nav-link"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    onClick={() => {
+                      setMobileMenuOpen(false);
+                      setProductsDropdownOpen(false);
+                    }}
+                  >
+                    {product.label}
+                  </a>
+                ) : (
+                  <Link
+                    key={product.path}
+                    to={product.path}
+                    className={`nav-link ${isActive(product.path) ? "active" : ""}`}
+                    onClick={() => {
+                      setMobileMenuOpen(false);
+                      setProductsDropdownOpen(false);
+                    }}
+                  >
+                    {product.label}
+                  </Link>
+                )
               ))}
             </div>
           )}
@@ -153,13 +170,25 @@ export default function Layout() {
               </button>
               <div className="dropdown-content">
                 {productsDropdown.map((product) => (
-                  <Link
-                    key={product.path}
-                    to={product.path}
-                    className={`nav-link ${isActive(product.path) ? "active" : ""}`}
-                  >
-                    {product.label}
-                  </Link>
+                  product.external ? (
+                    <a
+                      key={product.path}
+                      href={product.path}
+                      className="nav-link"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      {product.label}
+                    </a>
+                  ) : (
+                    <Link
+                      key={product.path}
+                      to={product.path}
+                      className={`nav-link ${isActive(product.path) ? "active" : ""}`}
+                    >
+                      {product.label}
+                    </Link>
+                  )
                 ))}
               </div>
             </div>
@@ -233,6 +262,7 @@ export default function Layout() {
               <Link to="/nova">Nova Bot</Link>
               <Link to="/nova-wallet">Nova Wallet</Link>
               <Link to="/nova-desk">Nova Desk</Link>
+              <a href="https://app.inferenco.com" target="_blank" rel="noopener noreferrer">Nova Ecosystem</a>
             </div>
             <div className="footer-links">
               <h4>Resources</h4>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -4,10 +4,13 @@ import type { PageType } from "../types";
 
 const navLinks: { label: string; path: string; page: PageType }[] = [
   { label: "Home", path: "/", page: "home" },
-  { label: "Nova", path: "/nova", page: "nova" },
+  { label: "Docs", path: "/docs", page: "docs" },
+];
+
+const productsDropdown = [
+  { label: "Nova Bot", path: "/nova", page: "nova" },
   { label: "Nova Wallet", path: "/nova-wallet", page: "nova-wallet" },
   { label: "Nova Desk", path: "/nova-desk", page: "nova-desk" },
-  { label: "Docs", path: "/docs", page: "docs" },
 ];
 
 const socialLinks = [
@@ -23,6 +26,7 @@ const socialLinks = [
 export default function Layout() {
   const location = useLocation();
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const [productsDropdownOpen, setProductsDropdownOpen] = useState(false);
   // Read theme synchronously on first render to prevent blink
   const [theme, setTheme] = useState<"light" | "dark">(() => {
     if (typeof window !== "undefined") {
@@ -73,6 +77,31 @@ export default function Layout() {
             {link.label}
           </Link>
         ))}
+        <div className="mobile-dropdown">
+          <button
+            className="mobile-dropdown-toggle"
+            onClick={() => setProductsDropdownOpen(!productsDropdownOpen)}
+          >
+            Products <i className={`fas ${productsDropdownOpen ? "fa-chevron-up" : "fa-chevron-down"}`} />
+          </button>
+          {productsDropdownOpen && (
+            <div className="mobile-dropdown-content">
+              {productsDropdown.map((product) => (
+                <Link
+                  key={product.path}
+                  to={product.path}
+                  className={`nav-link ${isActive(product.path) ? "active" : ""}`}
+                  onClick={() => {
+                    setMobileMenuOpen(false);
+                    setProductsDropdownOpen(false);
+                  }}
+                >
+                  {product.label}
+                </Link>
+              ))}
+            </div>
+          )}
+        </div>
         <div className="social-links-mobile">
           {socialLinks.map((link) => (
             <a
@@ -116,6 +145,22 @@ export default function Layout() {
                 {link.label}
               </Link>
             ))}
+            <div className="dropdown">
+              <button className="dropdown-toggle">
+                Products <i className="fas fa-chevron-down" />
+              </button>
+              <div className="dropdown-content">
+                {productsDropdown.map((product) => (
+                  <Link
+                    key={product.path}
+                    to={product.path}
+                    className={`nav-link ${isActive(product.path) ? "active" : ""}`}
+                  >
+                    {product.label}
+                  </Link>
+                ))}
+              </div>
+            </div>
           </div>
 
           <div className="nav-social">
@@ -186,6 +231,9 @@ export default function Layout() {
               <Link to="/nova">Nova Bot</Link>
               <Link to="/nova-wallet">Nova Wallet</Link>
               <Link to="/nova-desk">Nova Desk</Link>
+            </div>
+            <div className="footer-links">
+              <h4>Resources</h4>
               <Link to="/docs">Documentation</Link>
             </div>
             <div className="footer-links">

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -81,11 +81,13 @@ export default function Layout() {
           <button
             className="mobile-dropdown-toggle"
             onClick={() => setProductsDropdownOpen(!productsDropdownOpen)}
+            aria-expanded={productsDropdownOpen}
+            aria-controls="mobile-products-dropdown"
           >
-            Products <i className={`fas ${productsDropdownOpen ? "fa-chevron-up" : "fa-chevron-down"}`} />
+            Products <i className="fas fa-chevron-down" />
           </button>
           {productsDropdownOpen && (
-            <div className="mobile-dropdown-content">
+            <div className="mobile-dropdown-content" id="mobile-products-dropdown">
               {productsDropdown.map((product) => (
                 <Link
                   key={product.path}

--- a/src/components/LightboxGallery.tsx
+++ b/src/components/LightboxGallery.tsx
@@ -10,9 +10,10 @@ interface LightboxGalleryProps {
   images: LightboxImage[];
   thumbnailWidth?: string;
   thumbnailHeight?: string;
+  className?: string;
 }
 
-export default function LightboxGallery({ images, thumbnailWidth = '800px', thumbnailHeight }: LightboxGalleryProps) {
+export default function LightboxGallery({ images, thumbnailWidth = '800px', thumbnailHeight, className = '' }: LightboxGalleryProps) {
   const [lightboxOpen, setLightboxOpen] = useState(false);
   const [currentIndex, setCurrentIndex] = useState(0);
   const [isDragging, setIsDragging] = useState(false);
@@ -150,8 +151,9 @@ export default function LightboxGallery({ images, thumbnailWidth = '800px', thum
 
   return (
     <>
-      <div style={{ position: 'relative', margin: '24px 0' }}>
+      <div className={`lightbox-gallery ${className}`} style={{ position: 'relative', margin: '24px 0' }}>
         <div
+          className="lightbox-carousel"
           ref={carouselRef}
           onMouseDown={startDrag}
           style={{
@@ -177,11 +179,13 @@ export default function LightboxGallery({ images, thumbnailWidth = '800px', thum
               onAuxClick={(e) => {
                 e.preventDefault();
               }}
+              className="lightbox-slide"
               style={{ flexShrink: 0 }}
             >
               <img
                 src={img.src}
                 alt={img.alt}
+                className="lightbox-thumbnail"
                 style={{
                   borderRadius: '8px',
                   border: '1px solid #e0e0e0',
@@ -198,6 +202,7 @@ export default function LightboxGallery({ images, thumbnailWidth = '800px', thum
         </div>
 
         <button
+          className="lightbox-carousel-button lightbox-carousel-button-prev"
           onClick={() => scrollCarousel('prev')}
           style={{
             position: 'absolute',
@@ -218,9 +223,10 @@ export default function LightboxGallery({ images, thumbnailWidth = '800px', thum
           }}
           aria-label="Previous"
         >
-          &lt;
+          <i className="fas fa-chevron-left" aria-hidden="true" />
         </button>
         <button
+          className="lightbox-carousel-button lightbox-carousel-button-next"
           onClick={() => scrollCarousel('next')}
           style={{
             position: 'absolute',
@@ -241,7 +247,7 @@ export default function LightboxGallery({ images, thumbnailWidth = '800px', thum
           }}
           aria-label="Next"
         >
-          &gt;
+          <i className="fas fa-chevron-right" aria-hidden="true" />
         </button>
       </div>
 

--- a/src/index.css
+++ b/src/index.css
@@ -736,6 +736,7 @@ html.light .dropdown-content .nav-link.active {
 /* Mobile Dropdown */
 .mobile-dropdown {
     position: relative;
+    width: 100%;
 }
 
 .mobile-dropdown-toggle {
@@ -750,6 +751,8 @@ html.light .dropdown-content .nav-link.active {
     align-items: center;
     padding: 1rem 0;
     border-bottom: 1px solid var(--brand-primary);
+    text-align: left;
+    transition: color var(--transition-speed) ease;
 }
 
 html.light .mobile-dropdown-toggle {
@@ -760,17 +763,27 @@ html.light .mobile-dropdown-toggle {
     color: var(--brand-accent);
 }
 
+.mobile-dropdown-toggle i {
+    transition: transform var(--transition-speed) ease;
+}
+
+.mobile-dropdown-toggle[aria-expanded="true"] i {
+    transform: rotate(180deg);
+}
+
 .mobile-dropdown-content {
     display: none;
     padding-left: 1rem;
     border-left: 1px solid var(--brand-primary);
+    margin-top: 0.5rem;
 }
 
 html.light .mobile-dropdown-content {
     border-left-color: rgba(45, 108, 255, 0.12);
 }
 
-.mobile-dropdown-content.active {
+.mobile-dropdown-content.active,
+.mobile-dropdown .mobile-dropdown-content {
     display: block;
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -616,15 +616,21 @@ html.light .navbar {
 
 .nav-links {
     display: flex;
+    align-items: center;
     gap: 2rem;
 }
 
-.nav-links .nav-link {
+.nav-links .nav-link,
+.dropdown-toggle {
     font-size: 1rem;
     font-weight: 500;
+    line-height: 1.5;
     color: var(--text-secondary);
     position: relative;
     padding: 0.5rem 0;
+    min-height: 2.5rem;
+    display: inline-flex;
+    align-items: center;
 }
 
 .nav-links .nav-link::after {
@@ -651,21 +657,16 @@ html.light .navbar {
 /* Dropdown menu for Products */
 .dropdown {
     position: relative;
-    display: inline-block;
+    display: flex;
+    align-items: center;
 }
 
 .dropdown-toggle {
     background: none;
     border: none;
-    color: var(--text-secondary);
-    font-size: 1rem;
-    font-weight: 500;
+    font: inherit;
     cursor: pointer;
-    display: flex;
-    align-items: center;
     gap: 0.5rem;
-    padding: 0.5rem 0;
-    position: relative;
 }
 
 .dropdown-toggle::after {
@@ -1822,6 +1823,25 @@ html.light .docs-sidebar::-webkit-scrollbar-track {
     margin-top: 1rem;
 }
 
+.lightbox-carousel-button {
+    background: rgba(255, 255, 255, 0.96) !important;
+    border: 1px solid rgba(45, 108, 255, 0.28) !important;
+    color: #081421 !important;
+    box-shadow: 0 0.5rem 1.5rem rgba(0, 0, 0, 0.28) !important;
+}
+
+.lightbox-carousel-button:hover,
+.lightbox-carousel-button:focus-visible {
+    background: #ffffff !important;
+    border-color: var(--brand-accent) !important;
+    color: var(--brand-primary) !important;
+    outline: none;
+}
+
+.lightbox-carousel-button i {
+    pointer-events: none;
+}
+
 /* Responsive Design - Mobile and Medium (Tablet) devices */
 @media (max-width: 1024px) {
     h1 {
@@ -1864,6 +1884,58 @@ html.light .docs-sidebar::-webkit-scrollbar-track {
 
     .features-grid {
         grid-template-columns: 1fr;
+    }
+
+    .desktop-screenshot-gallery {
+        margin-inline: calc(50% - 50vw) !important;
+        padding-inline: 1.25rem;
+    }
+
+    .desktop-screenshot-gallery .lightbox-carousel {
+        gap: 0 !important;
+        scroll-snap-type: x mandatory;
+        scrollbar-width: none;
+    }
+
+    .desktop-screenshot-gallery .lightbox-carousel::-webkit-scrollbar {
+        display: none;
+    }
+
+    .desktop-screenshot-gallery .lightbox-slide {
+        flex: 0 0 100% !important;
+        display: flex;
+        justify-content: center;
+        scroll-snap-align: center;
+    }
+
+    .desktop-screenshot-gallery .lightbox-thumbnail {
+        width: min(100%, calc(100vw - 2.5rem)) !important;
+        min-width: 0 !important;
+        max-width: 760px;
+        height: auto !important;
+        object-fit: contain !important;
+    }
+
+    .desktop-screenshot-gallery .lightbox-carousel-button {
+        top: auto !important;
+        bottom: -3.25rem;
+        transform: none !important;
+        width: 2.75rem !important;
+        height: 2.75rem !important;
+        font-size: 1rem !important;
+        z-index: 2;
+    }
+
+    .desktop-screenshot-gallery .lightbox-carousel-button-prev {
+        left: calc(50% - 3.5rem) !important;
+    }
+
+    .desktop-screenshot-gallery .lightbox-carousel-button-next {
+        right: calc(50% - 3.5rem) !important;
+    }
+
+    #nova-desk-gallery {
+        padding-bottom: 5rem;
     }
 
     .pricing-table {

--- a/src/index.css
+++ b/src/index.css
@@ -648,6 +648,138 @@ html.light .navbar {
     color: var(--text-primary);
 }
 
+/* Dropdown menu for Products */
+.dropdown {
+    position: relative;
+    display: inline-block;
+}
+
+.dropdown-toggle {
+    background: none;
+    border: none;
+    color: var(--text-secondary);
+    font-size: 1rem;
+    font-weight: 500;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 0;
+    position: relative;
+}
+
+.dropdown-toggle::after {
+    content: "";
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 0;
+    height: 2px;
+    background: var(--brand-primary);
+    transition: width var(--transition-speed) ease;
+}
+
+.dropdown-toggle:hover::after {
+    width: 100%;
+}
+
+.dropdown-toggle:hover,
+.dropdown-toggle:focus {
+    color: var(--text-primary);
+    outline: none;
+}
+
+.dropdown-content {
+    display: none;
+    position: absolute;
+    top: 100%;
+    left: 0;
+    background: var(--bg-secondary);
+    backdrop-filter: blur(8px);
+    min-width: 200px;
+    box-shadow: 0 8px 16px rgba(0, 0, 0, 0.2);
+    border: 1px solid var(--brand-primary);
+    border-radius: var(--radius);
+    z-index: 1000;
+    padding: 0.5rem 0;
+}
+
+.dropdown:hover .dropdown-content {
+    display: block;
+}
+
+.dropdown-content .nav-link {
+    display: block;
+    padding: 0.75rem 1.5rem;
+    color: var(--text-secondary);
+    border-bottom: none;
+    white-space: nowrap;
+}
+
+.dropdown-content .nav-link:hover,
+.dropdown-content .nav-link.active {
+    color: var(--text-primary);
+    background: rgba(255, 255, 255, 0.05);
+}
+
+html.light .dropdown-content {
+    background: var(--surface-elevated);
+    border-color: rgba(45, 108, 255, 0.12);
+    box-shadow: 0 8px 16px rgba(45, 108, 255, 0.1);
+}
+
+html.light .dropdown-content .nav-link:hover,
+html.light .dropdown-content .nav-link.active {
+    background: rgba(45, 108, 255, 0.08);
+}
+
+/* Mobile Dropdown */
+.mobile-dropdown {
+    position: relative;
+}
+
+.mobile-dropdown-toggle {
+    width: 100%;
+    background: none;
+    border: none;
+    color: var(--text-primary);
+    font-size: 1.25rem;
+    cursor: pointer;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1rem 0;
+    border-bottom: 1px solid var(--brand-primary);
+}
+
+html.light .mobile-dropdown-toggle {
+    border-bottom-color: rgba(45, 108, 255, 0.12);
+}
+
+.mobile-dropdown-toggle:hover {
+    color: var(--brand-accent);
+}
+
+.mobile-dropdown-content {
+    display: none;
+    padding-left: 1rem;
+    border-left: 1px solid var(--brand-primary);
+}
+
+html.light .mobile-dropdown-content {
+    border-left-color: rgba(45, 108, 255, 0.12);
+}
+
+.mobile-dropdown-content.active {
+    display: block;
+}
+
+.mobile-dropdown-content .nav-link {
+    font-size: 1.1rem;
+    padding: 0.75rem 0;
+    border-bottom: none;
+}
+
 /* Social link styling */
 .nav-social {
     display: flex;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -167,6 +167,37 @@ export default function Home() {
                 Learn More
               </Link>
             </div>
+
+            {/* Nova Ecosystem Card */}
+            <div className="feature-card portfolio-card">
+              <img
+                src="assets/logos/nova.png"
+                alt="Nova Ecosystem logo"
+                className="portfolio-logo"
+              />
+              <h4>Nova Ecosystem</h4>
+              <p>
+                Browser-based dApp for the Cedra Network featuring events management,
+                gaming hub with poker and casino, and community tools. Built with React
+                and Move smart contracts for a seamless Web3 experience.
+              </p>
+              <div className="portfolio-tags">
+                <span className="tag">dApp</span>
+                <span className="tag">Cedra</span>
+                <span className="tag">Gaming</span>
+                <span className="tag">Events</span>
+                <span className="tag">Web3</span>
+              </div>
+              <a
+                href="https://app.inferenco.com"
+                className="cta-button"
+                style={{ marginTop: "1rem" }}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Visit dApp
+              </a>
+            </div>
           </div>
         </div>
       </section>

--- a/src/pages/NovaDesk.tsx
+++ b/src/pages/NovaDesk.tsx
@@ -165,7 +165,7 @@ export default function NovaDesk() {
 
       <section id="nova-desk-gallery" className="section">
         <div className="container">
-          <LightboxGallery images={deskImages} thumbnailWidth="760px" />
+          <LightboxGallery images={deskImages} thumbnailWidth="760px" className="desktop-screenshot-gallery" />
         </div>
       </section>
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,14 @@
 // Page types
 export type PageType = 'home' | 'nova' | 'nova-wallet' | 'nova-desk' | 'docs';
 
+// Product dropdown item type
+export interface ProductDropdownItem {
+  label: string;
+  path: string;
+  page?: PageType;
+  external?: boolean;
+}
+
 // Navigation link type
 export interface NavLink {
   label: string;


### PR DESCRIPTION
## Summary
- Grouped Nova Bot, Nova Wallet, Nova Desk, and Nova Ecosystem under a **Products dropdown** in the navigation bar
- Added **Nova Ecosystem** to the Products dropdown with a link to [https://app.inferenco.com](https://app.inferenco.com)
- Added **Nova Ecosystem** card to the **Portfolio section** on the Home page
- Fixed mobile dropdown visibility and added smooth transitions
- Added type definitions for better TypeScript support

## Changes
### Navigation
- Replaced individual Nova product links with a **Products dropdown** in both desktop and mobile menus
- Added **Nova Ecosystem** as an external link (opens in new tab)
- Updated footer to include Nova Ecosystem under Products

### Portfolio
- Added Nova Ecosystem card with description, tags (dApp, Cedra, Gaming, Events, Web3), and "Visit dApp" button

### Technical
- Added `ProductDropdownItem` type for type safety
- Fixed mobile dropdown CSS to ensure proper display
- Added smooth transitions for dropdown interactions

## Files Changed
- `src/components/Layout.tsx` (navigation and footer updates)
- `src/index.css` (dropdown styles for desktop and mobile)
- `src/pages/Home.tsx` (Portfolio section update)
- `src/types/index.ts` (type definitions)
