### PR TITLE
feat: mark Nova Bot as out of service and add demo video

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -210,6 +210,9 @@ export default function Home() {
                 Features transparent pay-per-use pricing, blockchain integration,
                 and 24/7 automated community support.
               </p>
+              <p style={{ color: "var(--text-secondary)", fontSize: "0.875rem", margin: "0.5rem 0" }}>
+                <em>⚠️ Currently unavailable - significant update in progress</em>
+              </p>
               <div className="portfolio-tags">
                 <span className="tag">AI Assistant</span>
                 <span className="tag">Telegram Bot</span>

--- a/src/pages/Nova.tsx
+++ b/src/pages/Nova.tsx
@@ -23,12 +23,20 @@ export default function Nova() {
           <p>
             Transparent platform with pay‑per‑use pricing and reliable service.
           </p>
+          <div className="maintenance-notice" style={{ background: "var(--background-secondary)", padding: "1rem", borderRadius: "0.5rem", margin: "1rem 0", border: "1px solid var(--border)" }}>
+            <p style={{ margin: 0, color: "var(--text-secondary)" }}>
+              <strong>⚠️ Nova Bot is currently unavailable</strong><br />
+              We are working on a significant update. The bot will be back soon with improved features and a new AI model.
+            </p>
+          </div>
           <a
             href="https://t.me/NovaInferencoBot"
             className="cta-button"
             aria-label="Start with Nova Bot"
+            style={{ opacity: 0.6, cursor: "not-allowed" }}
+            onClick={(e) => { e.preventDefault(); }}
           >
-            Start with Nova Bot
+            Start with Nova Bot (Temporarily Unavailable)
           </a>
         </div>
       </section>
@@ -257,22 +265,16 @@ export default function Nova() {
         <div className="container">
           <h2 className="section-title">Pricing</h2>
           <p>
-            <strong>Usage Pricing (Nova)</strong><br />Prices
-            shown in USD equivalent — billed in CEDRA or EURC
-            at current market rate.
+            <strong>Usage Pricing (Nova)</strong><br />
+            Prices shown in USD equivalent — billed in CEDRA or EURC at current market rate.
+          </p>
+          <p style={{ color: "var(--text-secondary)", marginBottom: "2rem" }}>
+            <em>Pricing information will be updated when the new AI model is deployed.</em>
           </p>
           <div className="pricing-table">
             <div className="pricing-item">
-              <h4>GPT‑5</h4>
-              <p>$0.00410 per 1k tokens</p>
-            </div>
-            <div className="pricing-item">
-              <h4>GPT‑5‑mini</h4>
-              <p>$0.00082 per 1k tokens</p>
-            </div>
-            <div className="pricing-item">
-              <h4>Sentinel (GPT‑5‑nano)</h4>
-              <p>$0.00016 per 1k tokens</p>
+              <h4>Advanced AI Model</h4>
+              <p>Pricing coming soon</p>
             </div>
             <div className="pricing-item">
               <h4>Image Generation</h4>
@@ -288,21 +290,12 @@ export default function Nova() {
             </div>
             <div className="pricing-item">
               <h4>MCP Tools</h4>
-              <p>$0.00082 per 1k tokens (output)</p>
+              <p>Pricing coming soon</p>
               <p style={{ fontSize: "0.75rem", color: "var(--muted)", marginTop: "0.25rem" }}>
                 Minimum charge per request
               </p>
             </div>
           </div>
-          <p style={{ fontSize: "0.875rem", color: "var(--muted)", marginTop: "1rem" }}>
-            Note: final costs depend on model choice and tool
-            complexity; Nova charges according to metered LLM
-            token usage in real time from your account. MCP
-            tools (market data, price predictions, social
-            insights, etc.) are priced based on output tokens at
-            the same rate as GPT-5-mini ($0.00082 per 1k
-            tokens), with a minimum charge per request.
-          </p>
         </div>
       </section>
 
@@ -320,8 +313,10 @@ export default function Nova() {
             href="https://t.me/NovaInferencoBot"
             className="cta-button"
             aria-label="Start with Nova Bot"
+            style={{ opacity: 0.6, cursor: "not-allowed" }}
+            onClick={(e) => { e.preventDefault(); }}
           >
-            Start with Nova Bot
+            Start with Nova Bot (Temporarily Unavailable)
           </a>
         </div>
       </section>

--- a/src/pages/Nova.tsx
+++ b/src/pages/Nova.tsx
@@ -23,6 +23,16 @@ export default function Nova() {
           <p>
             Transparent platform with pay‑per‑use pricing and reliable service.
           </p>
+          <p style={{ marginBottom: '1.5rem' }}>
+            <a
+              href="https://youtu.be/2ETNllY2yq8?si=_QYcjC8DGyQ1vAnt"
+              className="demo-link"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              🎥 Watch Demo Video
+            </a>
+          </p>
           <div className="maintenance-notice" style={{ background: "var(--background-secondary)", padding: "1rem", borderRadius: "0.5rem", margin: "1rem 0", border: "1px solid var(--border)" }}>
             <p style={{ margin: 0, color: "var(--text-secondary)" }}>
               <strong>⚠️ Nova Bot is currently unavailable</strong><br />

--- a/src/pages/docs/NovaAPIDocs.tsx
+++ b/src/pages/docs/NovaAPIDocs.tsx
@@ -11,7 +11,7 @@ export default function NovaAPIDocs({ hash }: { hash: string }) {
         <ul>
           <li><strong>RESTful Endpoints:</strong> Simple HTTP-based API with JSON request/response format. Base URL: <code>https://gateway.inferenco.com</code></li>
           <li><strong>API Key Authentication:</strong> Secure Bearer token authentication for all requests. Generate and manage multiple API keys with different configurations</li>
-          <li><strong>AI Model Access:</strong> Programmatic access to advanced language models (GPT-5, GPT-5-mini) with configurable parameters (verbosity, reasoning mode, token limits)</li>
+          <li><strong>AI Model Access:</strong> Programmatic access to advanced language models with configurable parameters (verbosity, reasoning mode, token limits)</li>
           <li><strong>Automatic Tool Calling:</strong> AI automatically selects and calls appropriate tools based on your prompts, including market data, price predictions, social intelligence, automated reports, image generation, web search, and more</li>
           <li><strong>Knowledge Base Integration (RAG):</strong> Upload documents to your API key's vector store for context-aware responses. The API automatically searches your knowledge base when relevant</li>
           <li><strong>Streaming Responses:</strong> Support for Server-Sent Events (SSE) for real-time streaming of AI responses</li>
@@ -176,7 +176,7 @@ export default function NovaAPIDocs({ hash }: { hash: string }) {
           <li><strong>Social Insights:</strong> Get crypto social media intelligence and sentiment analysis. Provides Twitter/X and Telegram social analytics including trending tokens, top mentions, smart account stats, mentions search, event summaries, trending narratives, token news, and trending contract addresses. User profiles are returned as clickable profile links (e.g., <code>[username](https://x.com/username)</code>) instead of @username tags.</li>
           <li><strong>Automated Reports:</strong> Generate automated, intelligent crypto intelligence reports. Create scheduled reports that analyze blockchain data, track market trends, monitor token opportunities, and discover yield farming opportunities. Reports are available in both Markdown (human-readable) and JSON (machine-readable) formats. Supports creating reports, listing executions, getting report content, and managing report lifecycle.</li>
         </ul>
-        <p><strong>MCP Tools Pricing:</strong> $0.00082 per 1k tokens (output) — same rate as GPT-5-mini. Pricing is based on output tokens with a minimum charge per request.</p>
+        <p><strong>MCP Tools Pricing:</strong> Pricing will be updated when the new AI model is deployed. Pricing is based on output tokens with a minimum charge per request.</p>
 
         <h2>Example Prompts Using Tools</h2>
         <p>Here are example prompts you can use with the Nova API to trigger different tools:</p>
@@ -185,7 +185,7 @@ export default function NovaAPIDocs({ hash }: { hash: string }) {
         <div className="code-block">
           <code>{`{
   "input": "Predict Bitcoin price in 1 hour",
-  "model": "gpt-5",
+  "model": "advanced",
   "verbosity": "Medium",
   "max_tokens": 2000,
   "reasoning": false
@@ -195,7 +195,7 @@ export default function NovaAPIDocs({ hash }: { hash: string }) {
         <div className="code-block">
           <code>{`{
   "input": "What will Ethereum price be in 1 week? Show me a forecast with chart data",
-  "model": "gpt-5",
+  "model": "advanced",
   "verbosity": "High",
   "max_tokens": 2000,
   "reasoning": false
@@ -205,7 +205,7 @@ export default function NovaAPIDocs({ hash }: { hash: string }) {
         <div className="code-block">
           <code>{`{
   "input": "Get a 4-hour price forecast for Solana",
-  "model": "gpt-5-mini",
+  "model": "standard",
   "verbosity": "Medium",
   "max_tokens": 1500,
   "reasoning": false
@@ -215,7 +215,7 @@ export default function NovaAPIDocs({ hash }: { hash: string }) {
         <div className="code-block">
           <code>{`{
   "input": "Forecast CEDRA price for 1 month with confidence intervals",
-  "model": "gpt-5",
+  "model": "advanced",
   "verbosity": "High",
   "max_tokens": 2000,
   "reasoning": false
@@ -226,7 +226,7 @@ export default function NovaAPIDocs({ hash }: { hash: string }) {
         <div className="code-block">
           <code>{`{
   "input": "Show me trending pools on Cedra Network",
-  "model": "gpt-5-mini",
+  "model": "standard",
   "verbosity": "Medium",
   "max_tokens": 1500,
   "reasoning": false
@@ -236,7 +236,7 @@ export default function NovaAPIDocs({ hash }: { hash: string }) {
         <div className="code-block">
           <code>{`{
   "input": "Find pools for CEDRA/EURC on Cedra Network",
-  "model": "gpt-5-mini",
+  "model": "standard",
   "verbosity": "Low",
   "max_tokens": 1000,
   "reasoning": false
@@ -246,7 +246,7 @@ export default function NovaAPIDocs({ hash }: { hash: string }) {
         <div className="code-block">
           <code>{`{
   "input": "What's the current Fear & Greed Index?",
-  "model": "gpt-5-mini",
+  "model": "standard",
   "verbosity": "Low",
   "max_tokens": 500,
   "reasoning": false
@@ -256,7 +256,7 @@ export default function NovaAPIDocs({ hash }: { hash: string }) {
         <div className="code-block">
           <code>{`{
   "input": "Get historical price data for Ethereum for the last 7 days",
-  "model": "gpt-5-mini",
+  "model": "standard",
   "verbosity": "Medium",
   "max_tokens": 1500,
   "reasoning": false
@@ -267,7 +267,7 @@ export default function NovaAPIDocs({ hash }: { hash: string }) {
         <div className="code-block">
           <code>{`{
   "input": "Generate an image of a futuristic city with flying cars",
-  "model": "gpt-5",
+  "model": "advanced",
   "verbosity": "Medium",
   "max_tokens": 1000,
   "reasoning": false
@@ -278,7 +278,7 @@ export default function NovaAPIDocs({ hash }: { hash: string }) {
         <div className="code-block">
           <code>{`{
   "input": "What does my documentation say about API integration?",
-  "model": "gpt-5",
+  "model": "advanced",
   "verbosity": "High",
   "max_tokens": 2000,
   "reasoning": false
@@ -289,7 +289,7 @@ export default function NovaAPIDocs({ hash }: { hash: string }) {
         <div className="code-block">
           <code>{`{
   "input": "Search for the latest news about Cedra Network blockchain",
-  "model": "gpt-5",
+  "model": "advanced",
   "verbosity": "Medium",
   "max_tokens": 2000,
   "reasoning": false
@@ -300,7 +300,7 @@ export default function NovaAPIDocs({ hash }: { hash: string }) {
         <div className="code-block">
           <code>{`{
   "input": "Calculate the ROI if I invest $1000 at 8% annual return for 5 years",
-  "model": "gpt-5-mini",
+  "model": "standard",
   "verbosity": "Low",
   "max_tokens": 500,
   "reasoning": false
@@ -311,7 +311,7 @@ export default function NovaAPIDocs({ hash }: { hash: string }) {
         <div className="code-block">
           <code>{`{
   "input": "What tokens are trending on Twitter right now?",
-  "model": "gpt-5-mini",
+  "model": "standard",
   "verbosity": "Medium",
   "max_tokens": 1500,
   "reasoning": false
@@ -321,7 +321,7 @@ export default function NovaAPIDocs({ hash }: { hash: string }) {
         <div className="code-block">
           <code>{`{
   "input": "Show me the top mentions of Bitcoin on X in the last 24 hours",
-  "model": "gpt-5-mini",
+  "model": "standard",
   "verbosity": "Medium",
   "max_tokens": 1500,
   "reasoning": false
@@ -331,7 +331,7 @@ export default function NovaAPIDocs({ hash }: { hash: string }) {
         <div className="code-block">
           <code>{`{
   "input": "Get smart stats for the Twitter account @elonmusk",
-  "model": "gpt-5-mini",
+  "model": "standard",
   "verbosity": "Low",
   "max_tokens": 1000,
   "reasoning": false
@@ -341,7 +341,7 @@ export default function NovaAPIDocs({ hash }: { hash: string }) {
         <div className="code-block">
           <code>{`{
   "input": "What are the trending narratives in crypto right now?",
-  "model": "gpt-5",
+  "model": "advanced",
   "verbosity": "High",
   "max_tokens": 2000,
   "reasoning": false
@@ -351,7 +351,7 @@ export default function NovaAPIDocs({ hash }: { hash: string }) {
         <div className="code-block">
           <code>{`{
   "input": "Search for mentions of Cedra Network on Twitter and summarize the sentiment",
-  "model": "gpt-5",
+  "model": "advanced",
   "verbosity": "Medium",
   "max_tokens": 2000,
   "reasoning": false
@@ -362,7 +362,7 @@ export default function NovaAPIDocs({ hash }: { hash: string }) {
         <div className="code-block">
           <code>{`{
   "input": "I want to create report of daily yield farming across Aave, Compound, and Convex protocols",
-  "model": "gpt-5",
+  "model": "advanced",
   "verbosity": "Medium",
   "max_tokens": 2000,
   "reasoning": false
@@ -372,7 +372,7 @@ export default function NovaAPIDocs({ hash }: { hash: string }) {
         <div className="code-block">
           <code>{`{
   "input": "List all my reports",
-  "model": "gpt-5-mini",
+  "model": "standard",
   "verbosity": "Low",
   "max_tokens": 1000,
   "reasoning": false
@@ -382,7 +382,7 @@ export default function NovaAPIDocs({ hash }: { hash: string }) {
         <div className="code-block">
           <code>{`{
   "input": "Get the latest content for report 77d51445-4146-4ab4-bf5b-5e69bffe462c",
-  "model": "gpt-5-mini",
+  "model": "standard",
   "verbosity": "Medium",
   "max_tokens": 2000,
   "reasoning": false
@@ -392,7 +392,7 @@ export default function NovaAPIDocs({ hash }: { hash: string }) {
         <div className="code-block">
           <code>{`{
   "input": "Show me available datasets for creating reports",
-  "model": "gpt-5-mini",
+  "model": "standard",
   "verbosity": "Low",
   "max_tokens": 1000,
   "reasoning": false
@@ -554,7 +554,7 @@ export default function NovaAPIDocs({ hash }: { hash: string }) {
                   <td>model</td>
                   <td>string</td>
                   <td className="required">Yes</td>
-                  <td>AI model to use (e.g., "gpt-5", "gpt-5-mini")</td>
+                  <td>AI model to use (model options will be updated with the new deployment)</td>
                 </tr>
                 <tr>
                   <td>verbosity</td>
@@ -600,7 +600,7 @@ export default function NovaAPIDocs({ hash }: { hash: string }) {
           <div className="code-block">
             <code>{`{
   "text": "AI response text",
-  "model": "gpt-5",
+  "model": "advanced",
   "image_data": null,
   "tool_calls": [],
   "total_tokens": 150,
@@ -623,7 +623,7 @@ export default function NovaAPIDocs({ hash }: { hash: string }) {
         'Content-Type': 'application/json'
       },
       body: JSON.stringify({
-        model: 'gpt-5',
+        model: 'advanced',
         input: prompt,
         max_tokens: 2000,
         verbosity: 'Medium',

--- a/src/pages/docs/NovaBotDocs.tsx
+++ b/src/pages/docs/NovaBotDocs.tsx
@@ -4,12 +4,19 @@ export default function NovaBotDocs({ hash }: { hash: string }) {
       <div id="nova-bot-introduction" className={`docs-section ${hash === "nova-bot-introduction" ? "active" : ""}`}>
         <h1>Nova Bot - Introduction</h1>
 
+        <div className="maintenance-notice" style={{ background: "var(--background-secondary)", padding: "1rem", borderRadius: "0.5rem", margin: "1rem 0", border: "1px solid var(--border)" }}>
+          <p style={{ margin: 0, color: "var(--text-secondary)" }}>
+            <strong>⚠️ Nova Bot is currently unavailable</strong><br />
+            We are working on a significant update. The bot will be back soon with improved features and a new AI model.
+          </p>
+        </div>
+
         <p>Nova is a sophisticated AI-powered Telegram bot ecosystem with deep blockchain integration on Cedra Network. Nova provides advanced group management, AI-driven conversations with tool-calling capabilities, automated payment systems, content moderation, and decentralized governance features. It's designed for Telegram users and groups that need intelligent automation, financial operations, and comprehensive administrative controls.</p>
 
         <h2>What is Nova Bot?</h2>
         <p>Nova Bot combines cutting-edge AI technology with blockchain transparency to deliver:</p>
         <ul>
-          <li><strong>AI-Powered Conversations:</strong> Access to advanced language models (GPT-5, GPT-5-mini) with tool-calling capabilities</li>
+          <li><strong>AI-Powered Conversations:</strong> Access to advanced language models with tool-calling capabilities</li>
           <li><strong>Blockchain Integration:</strong> Multi-chain support across Cedra Network, Aptos, Solana, and 20+ EVM-compatible blockchains for transparent payments and transactions</li>
           <li><strong>Multi-Token Support:</strong> Work with native tokens and ERC-20 tokens across all supported chains (CEDRA, USDC, USDT, ETH, and more)</li>
           <li><strong>Market Data Tools:</strong> Real-time cryptocurrency prices, trending pools, DEX data, price predictions, and more</li>
@@ -29,6 +36,9 @@ export default function NovaBotDocs({ hash }: { hash: string }) {
 
         <h2>Getting Started with Nova Bot</h2>
         <p>To start using Nova Bot:</p>
+        <p style={{ color: "var(--text-secondary)" }}>
+          <em>Nova Bot is currently unavailable during our significant update. Please check back soon!</em>
+        </p>
         <ol>
           <li>Open Telegram and search for <a href="https://t.me/NovaInferencoBot" target="_blank" className="telegram-link"><i className="fab fa-telegram"></i> @NovaInferencoBot</a></li>
           <li>Click "Start" to begin</li>
@@ -190,12 +200,7 @@ export default function NovaBotDocs({ hash }: { hash: string }) {
 
         <div className="endpoint-item">
           <h4>Select Model</h4>
-          <p>Choose which AI model to use for your conversations. Available models include:</p>
-          <ul>
-            <li><strong>GPT-5:</strong> Most advanced model for complex tasks ($0.00410 per 1k tokens)</li>
-            <li><strong>GPT-5-mini:</strong> Faster, more cost-effective option ($0.00082 per 1k tokens)</li>
-            <li><strong>Sentinel (GPT-5-nano):</strong> Lightweight model for moderation ($0.00016 per 1k tokens)</li>
-          </ul>
+          <p>Choose which AI model to use for your conversations. Model options will be updated when the new AI model is deployed.</p>
           <p>You can also configure reasoning mode and other model preferences.</p>
         </div>
 
@@ -296,7 +301,7 @@ export default function NovaBotDocs({ hash }: { hash: string }) {
 
         <h3>MCP Tools (Blockchain & Data)</h3>
         <p>These tools are available through the MCP server and provide blockchain and market data capabilities:</p>
-        <p><strong>Cost:</strong> $0.00082 per 1k tokens (output) — same rate as GPT-5-mini. Pricing is based on output tokens with a minimum charge per request.</p>
+        <p><strong>Cost:</strong> Pricing will be updated when the new AI model is deployed. Pricing is based on output tokens with a minimum charge per request.</p>
 
         <div className="endpoint-item">
           <h4>Get Trending Pools</h4>


### PR DESCRIPTION
## Summary
- Mark Nova Bot as temporarily unavailable with maintenance notices
- Remove all references to GPT-5, GPT-5-mini, and GPT-5-nano models
- Replace model names with generic terms (advanced, standard)
- Update pricing sections to indicate pricing will be updated with new AI model
- Disable 'Start with Nova Bot' buttons with visual indication of unavailability
- Add out-of-service notice to Nova Bot card on Home page
- Add demo video link to Nova Bot page (https://youtu.be/2ETNllY2yq8?si=_QYcjC8DGyQ1vAnt)

## Files Changed
- src/pages/Home.tsx
- src/pages/Nova.tsx
- src/pages/docs/NovaAPIDocs.tsx
- src/pages/docs/NovaBotDocs.tsx